### PR TITLE
Refractor "Rebytes" to "Loops"

### DIFF
--- a/src/constructors/post.js
+++ b/src/constructors/post.js
@@ -35,12 +35,12 @@ module.exports = class post {
         })
     }
     /**
-     * Rebytes a post.
+     * Loops a post.
      * @example
-     * <post>.rebyte()
+     * <post>.loop()
      * .then((res) => console.log(res))
      */
-    rebyte() {
+    loop() {
         return new Promise((resolve, reject) => {
             this.client.baseRequest(`post/id/${this.id}/loop`, "POST", "postaction")
             .catch((err) => reject(err))


### PR DESCRIPTION
Currently this states that doing something such as post.rebyte will "Rebyte" a post, however what it really is doing is simply sending a loop request to the servers and not actually rebyting anything.